### PR TITLE
Update js-8.md

### DIFF
--- a/programming/javascript/release-notes/js-8.md
+++ b/programming/javascript/release-notes/js-8.md
@@ -44,7 +44,7 @@ noTitleIndex: true
 
 The class names of the built-in UI elements have changed
 
-| Previous versions | v8.8.0 & v8.8.3 |
+| Previous versions | v8.8.0+ |
 |:-:|:-:|
 | `dbrScanner-bg-loading` | `dce-bg-loading` |
 | `dbrScanner-bg-camera` | `dce-bg-camera` |


### PR DESCRIPTION
Looks funny that we're referencing 8.8.3 in 8.6 notes, changed to be more generic.