### PR TITLE
Update use-in-framework.md

### DIFF
--- a/programming/javascript/user-guide/use-in-framework.md
+++ b/programming/javascript/user-guide/use-in-framework.md
@@ -76,21 +76,21 @@ In order for these settings to take effect, `dynamsoft.config.ts` must be import
 
 ### Offline usage
 
-In some cases, you may need to use DBR-JS in an offline environment. You can download the [DBR-JS zip](https://www.dynamsoft.com/barcode-reader/downloads/1000003-confirmation/#js) package through the link, which contains all the necessary offline resources in the `./distributables` directory.
+In some cases, you may need to use DBR-JS in an offline environment. You can download the [DBR-JS zip](https://www.dynamsoft.com/barcode-reader/downloads/1000003-confirmation/#js) package through the link, which contains all the necessary offline resources in the `./dist` directory.
 
-**Step 1:** Copy the `./distributables` folder to your project.
+**Step 1:** Copy the `./dist` folder to your project.
 
 **Step 2:** In `dynamsoft.config.ts`, define the `engineResourcePaths`:
 
 ```javascript
 // Configures the root path where the .wasm files and other necessary resources for modules are located. Feel free to change it to your own location of these files
-CoreModule.engineResourcePaths.rootDirectory = '../assets/distributables';
+CoreModule.engineResourcePaths.rootDirectory = '../assets/dist';
 ```
 
 > Note:
 > 
-> We recommend not renaming any module files within the `./distributables` directory, as this may cause the rootDirectory configuration to not work properly. In such cases, you would need to define resource paths for each module individually.
-> In our case the packages are used only as static resources, we recommend moving the `./distributables` to a dedicated folder for static resources in your project to facilitate self-hosting.
+> We recommend not renaming any module files within the `./dist` directory, as this may cause the rootDirectory configuration to not work properly. In such cases, you would need to define resource paths for each module individually.
+> In our case the packages are used only as static resources, we recommend moving the `./dist` to a dedicated folder for static resources in your project to facilitate self-hosting.
 
 Next, we will demonstrate how to introduce `dynamsoft.config.ts` into a specific component. Don't skip the [Component for Reading Image](#component-for-reading-image) section even if you only need video barcode decoding.
 


### PR DESCRIPTION
use of 'distributables' in the docs and 'dist' in the actual JS folder caused a confusion for a customer.